### PR TITLE
feat(csp): add ability to inject a nonce value into preboot

### DIFF
--- a/src/server/server-preboot.module.ts
+++ b/src/server/server-preboot.module.ts
@@ -10,12 +10,14 @@ import {
 import { PlatformState } from '@angular/platform-server';
 import { PrebootRecordOptions } from '../common';
 import { getInlinePrebootCode } from './inline.preboot.code';
+import {PREBOOT_NONCE} from '../tokens';
 
-export function loadPrebootFactory(state: PlatformState, rendererFactory: RendererFactory2, opts: PrebootRecordOptions) {
+export function loadPrebootFactory(state: PlatformState, rendererFactory: RendererFactory2, opts: PrebootRecordOptions,
+                                   nonce: string) {
   return function() {
     const doc = state.getDocument();
     const inlinePrebootCode = getInlinePrebootCode(opts);
-    addInlineCodeToDocument(inlinePrebootCode, doc, rendererFactory);
+    addInlineCodeToDocument(inlinePrebootCode, doc, rendererFactory, nonce);
   };
 }
 
@@ -41,17 +43,19 @@ export class ServerPrebootModule {
           multi: true,
 
           // we need access to the document and renderer
-          deps: [PlatformState, RendererFactory2, PREBOOT_RECORD_OPTIONS]
+          deps: [PlatformState, RendererFactory2, PREBOOT_RECORD_OPTIONS, PREBOOT_NONCE]
         }
       ]
     };
   }
 }
 
-export function addInlineCodeToDocument(inlineCode: string, doc: Document, rendererFactory: RendererFactory2) {
+export function addInlineCodeToDocument(inlineCode: string, doc: Document, rendererFactory: RendererFactory2,
+                                        nonce: string) {
   const renderType: RendererType2 = { id: '-1', encapsulation: ViewEncapsulation.None, styles: [], data: {} };
   const renderer = rendererFactory.createRenderer(doc, renderType);
   const script = renderer.createElement('script');
+  renderer.setProperty(script, 'nonce', nonce);
   renderer.setValue(script, inlineCode);
   renderer.insertBefore(doc.head, script, doc.head.firstChild);
 }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,0 +1,3 @@
+import {InjectionToken} from '@angular/core';
+
+export const PREBOOT_NONCE = new InjectionToken<string>('PrebootNonce');


### PR DESCRIPTION
Since preboot is embedded as an inline script, it is incompatible
with the `script-src` CSP, unless users add the `unsafe-inline`
attribute. This creates extra risk for users, which this feature
seeks to correct.

Fixes #45 

This commit adds a `PREBOOT_NONCE` token that can be imported and
provided in a server application to add a `nonce` tag to the preboot
script on generation. Usage is as follows (demonstrated for Express):

```
import {PREBOOT_NONCE} from 'preboot/src/tokens';
import * as express from 'express';
import {v4} from 'uuid';
import * as csp from 'helmet-csp';

const app = express();

app.use((req, res, next) => {
  res.locals.nonce = v4();
  next();
});

app.use(csp({
  directives: {
    scriptSrc: [`'self'`, (req, res) => `'nonce-${ res.locals.nonce }'`]
    ...
  }
});

... express boilerplate ...

/* when it comes time to render the request, we can inject our new token */

app.get('*', (req, res) => {
  res.render('index', {
    req,
    res,
    providers: [
      {
	    provide: PREBOOT_NONCE,
	    useValue: res.locals.nonce
      }
    ]
  });
});

... other express route handling (see Universal guide for details) ...
```

**Please note that only the `nonce` tag will appear on the script,
the value is not rendered in modern browsers**. If you want to make
sure your `nonce` is generating correctly, you can add a callback
onto your render method to examine the resultant HTML as follows:

```
res.render('index', (req, res) => {
  ...
}, function(error, html) => {
  console.log(html);
  res.send(html);
});
```
  

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/preboot/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [x] server side
- [ ] client side
- [x] inline
- [ ] build process
- [ ] docs
- [ ] tests

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
remove unused proxy imports from some test files

Feature

* **What is the current behavior?** (You can also link to an open issue here)

No nonce tag is able to be added to the preboot script during rendering

* **What is the new behavior (if this is a feature change)?**

A nonce tag is able to be injected into preboot to be added to the script during rendering

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

None
