### PR TITLE
refactor(preboot): fix issue with default nonce, publish new version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preboot",
-  "version": "5.1.5",
+  "version": "5.1.6",
   "description": "Record server view events and play back to Angular client view",
   "scripts": {
     "inline": "rm -rf dist && mkdir dist && node src/build/inline.preboot.builder || true",

--- a/src/server/server-preboot.module.ts
+++ b/src/server/server-preboot.module.ts
@@ -1,22 +1,29 @@
 import {
-  InjectionToken,
-  ModuleWithProviders,
-  NgModule,
-  RendererFactory2,
-  RendererType2,
-  ViewEncapsulation,
-  APP_BOOTSTRAP_LISTENER
+    InjectionToken,
+    ModuleWithProviders,
+    NgModule,
+    RendererFactory2,
+    RendererType2,
+    ViewEncapsulation,
+    APP_BOOTSTRAP_LISTENER,
+    Inject,
+    Optional,
+    forwardRef
 } from '@angular/core';
 import { PlatformState } from '@angular/platform-server';
 import { PrebootRecordOptions } from '../common';
 import { getInlinePrebootCode } from './inline.preboot.code';
 
-export function loadPrebootFactory(state: PlatformState, rendererFactory: RendererFactory2, opts: PrebootRecordOptions, nonce: string) {
+export function loadPrebootFactory(state: PlatformState, rendererFactory: RendererFactory2, opts: PrebootRecordOptions, nonceOp: NonceOp) {
   return function() {
     const doc = state.getDocument();
     const inlinePrebootCode = getInlinePrebootCode(opts);
-    addInlineCodeToDocument(inlinePrebootCode, doc, rendererFactory, nonce);
+    addInlineCodeToDocument(inlinePrebootCode, doc, rendererFactory, nonceOp.nonce);
   };
+}
+
+export class NonceOp {
+  constructor(@Optional() @Inject(forwardRef(() => PREBOOT_NONCE)) public nonce: string) { }
 }
 
 export const PREBOOT_NONCE = new InjectionToken<string>('PrebootNonce');
@@ -31,7 +38,7 @@ export class ServerPrebootModule {
       ngModule: ServerPrebootModule,
       providers: [
         { provide: PREBOOT_RECORD_OPTIONS, useValue: opts },
-        { provide: PREBOOT_NONCE, useValue: Math.floor(Math.random() * 10000) + '' },
+        { provide : NonceOp, useClass: NonceOp },
         {
           // this likely will never be injected but need something to run the
           // factory function
@@ -43,7 +50,7 @@ export class ServerPrebootModule {
           multi: true,
 
           // we need access to the document and renderer
-          deps: [PlatformState, RendererFactory2, PREBOOT_RECORD_OPTIONS, PREBOOT_NONCE]
+          deps: [PlatformState, RendererFactory2, PREBOOT_RECORD_OPTIONS, NonceOp]
         }
       ]
     };
@@ -54,7 +61,9 @@ export function addInlineCodeToDocument(inlineCode: string, doc: Document, rende
   const renderType: RendererType2 = { id: '-1', encapsulation: ViewEncapsulation.None, styles: [], data: {} };
   const renderer = rendererFactory.createRenderer(doc, renderType);
   const script = renderer.createElement('script');
-  renderer.setProperty(script, 'nonce', nonce);
+  if (nonce) {
+      renderer.setProperty(script, 'nonce', nonce);
+  }
   renderer.setValue(script, inlineCode);
   renderer.insertBefore(doc.head, script, doc.head.firstChild);
 }


### PR DESCRIPTION
In the previous refactoring, a default provider was instantiated
for the nonce token. However, this would be greedily used before
it could be overridden by the real nonce. This PR adds the following:

* Adds a dependency class that adds the nonce token as an optional
  dependnecy and a forwardRef so that it delays instantitation, and
  also doesn't complain when there isn't a default (makes e2e happy)
* Add a null check on the now optional nonce to avoid adding the
  tag if a user doesn't want it
* Added nonce instructions to the README
* Bumped patch version