### PR TITLE
fix(preboot): use CustomEvent rather than Event

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,3 +219,7 @@ res.render('index', (req, res) => {
   res.send(html);
 });
 ```
+
+#### Browser support
+
+If you wish to support Internet Explorer 9-11, you will need to include a [Polyfill](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill) for `CustomEvent`.

--- a/src/lib/api/event.replayer.ts
+++ b/src/lib/api/event.replayer.ts
@@ -189,9 +189,15 @@ export class EventReplayer {
     prebootData.apps = [];
     this.clientNodeCache = {};
 
-    // sent event to documernt that signals preboot complete
-    const completeEvent = new Event('PrebootComplete');
-    doc.dispatchEvent(completeEvent);
+    // send event to document that signals preboot complete
+    // constructor is not supported by older browsers ( i.e. IE9-11 )
+    // in these browsers, the type of CustomEvent will be "object"
+    if (typeof CustomEvent === 'function') {
+      const completeEvent = new CustomEvent('PrebootComplete');
+      doc.dispatchEvent(completeEvent);
+    } else {
+      console.warn('Could not dispatch PrebootComplete event. You can fix this by including a polyfill for CustomEvent.');
+    }
   }
 
   setFocus(activeNode: NodeContext) {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/preboot/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [ ] server side
- [x] client side
- [ ] inline
- [ ] build process
- [x] docs
- [ ] tests

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Use CustomEvent for PrebootComplete event notification to simplify
  polyfill usage and improve browser support.
- Check CustomEvent type before creating a CustomEvent using the
  constructor. If the type is not a function, a warning is logged
  in the console to notify the user that PrebootComplete event
  could not be dispatched.
- Addition of a section in the README.md documenting the need of a
  CustomEvent polyfill.

* **What is the current behavior?** (You can also link to an open issue here)
Crashes on load in some browsers that are supported by Angular (IE 9/10/11) see #64 .

* **What is the new behavior (if this is a feature change)?**
This will make it easier to support IE11 using a CustomEvent `polyfill`.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking changes

* **Other information**:
Closes #64
