### PR TITLE
fix: make Preboot work with ngUpgrade

### DIFF
--- a/src/lib/api/event.recorder.spec.ts
+++ b/src/lib/api/event.recorder.spec.ts
@@ -32,6 +32,16 @@ describe('UNIT TEST event.recorder', function() {
       const actual = createBuffer(root);
       expect(actual).toBe(clientNode as HTMLElement);
     });
+
+    it('should add the "ng-non-bindable" attribute to serverNode', function () {
+      const root = <ServerClientRoot> {
+        serverSelector: 'div',
+        serverNode: getMockElement()
+      };
+
+      createBuffer(root);
+      expect(root.serverNode!.hasAttribute('ng-non-bindable')).toBe(true);
+    });
   });
 
   describe('getSelection()', function () {

--- a/src/lib/api/event.recorder.ts
+++ b/src/lib/api/event.recorder.ts
@@ -330,6 +330,9 @@ export function createBuffer(root: ServerClientRoot): HTMLElement {
   // insert the client node before the server and return it
   serverNode.parentNode.insertBefore(rootClientNode, serverNode);
 
+  // mark server node as not to be touched by AngularJS - needed for ngUpgrade
+  serverNode.setAttribute('ng-non-bindable', '');
+
   // return the rootClientNode
   return rootClientNode;
 }

--- a/src/lib/common/preboot.mocks.ts
+++ b/src/lib/common/preboot.mocks.ts
@@ -16,9 +16,22 @@ export function getMockOptions(): PrebootOptions {
 
 export function getMockElement(): Element {
   return {
+    ___attributes: new Map<string, string>(),
     cloneNode: () => { return { style: {} }; },
     parentNode: {
       insertBefore: function () {}
+    },
+    hasAttribute(key: string) {
+      return this.___attributes.has(key);
+    },
+    getAttribute(key: string) {
+      return this.___attributes.get(key);
+    },
+    setAttribute(key: string, value: string) {
+      this.___attributes.set(key, value);
+    },
+    removeAttribute(key: string) {
+      this.___attributes.delete(key);
     }
   } as any as Element;
 }


### PR DESCRIPTION
When AngularJS is used in an Angular app via ngUpgrade and Preboot is added
with buffering enabled, by default AngularJS will compile both app roots
(Angular would compile the first one only), leading - in turn - to Angular's
AppComponent being rendered twice, in both roots. That breaks the whole Preboot
functionality.

Adding the ng-non-bindable attribute to the server-rendered node works around
this difference in behavior.

README has a new section on how to manually trigger replaying events for
setups without bootstrap components, e.g. the canonical setup for ngUpgrade.

Fixes #67

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/preboot/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [ ] server side
- [x] client side
- [ ] inline
- [ ] build process
- [ ] docs
- [ ] tests

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

* **What is the current behavior?** (You can also link to an open issue here)

Preboot doesn't work with ngUpgrade when bufferring or automatically replaying events is enabled.

* **What is the new behavior (if this is a feature change)?**

Preboot works with ngUpgrade when bufferring is enabled and and replaying events is done manually (i.e. `noReply: true`). The needed setup is described in more detail in README.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:

Current `master` is broken so it's best to test this PR in a real project in tandem with #62. It may be landed before #62, though.
