### PR TITLE
fix: resolve Preboot race conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,24 +46,45 @@ import { AppComponent } from './app.component';
 export class AppModule { }
 ```
 
-The key part here for preboot is to include `PrebootModule.withConfig({ appRoot: 'app-root' })` where the `appRoot`
-is the selector(s) to find the root of your application. The options you can pass into `withConfig()` are in the [PrebootOptions](#PrebootOptions) section below. In most cases, however, you will only need to specify the `appRoot`.
+The key part here for preboot is to include `PrebootModule.withConfig({ appRoot: 'app-root' })` where the `appRoot` is the selector(s) to find the root of your application. The options you can pass into `withConfig()` are in the [PrebootOptions](#PrebootOptions) section below. In most cases, however, you will only need to specify the `appRoot`.
 
 #### Non-Angular Server Configuration
 
-```
-import { getInlinePrebootCode } from 'preboot';
+```ts
+import { getInlineDefinition, getInlineInvocation } from 'preboot';
 
 const prebootOptions = {};  // see PrebootRecordOptions section below
-const inlineCode = getInlinePrebootCode(prebootOptions);
+const inlineCodeDefinition = getInlineDefinition(prebootOptions);
+const inlineCodeInvocation = getInlineInvocation();
 
-// now simply insert the inlineCode into the HEAD section of your server view
+// now insert `inlineCodeDefinition` into a `<script>` tag in `<head>` and 
+// an `inlineCodeInvocation` copy just after the opening tag of each app root
 
+```
+
+```html
+<html>
+  <head>
+    <script><%= inlineCodeDefinition %></script>
+  </head>
+  <body>
+    <app1-root>
+      <script><%= inlineCodeInvocation %></script>
+      <h2>App1 header</h2>
+      <div>content</div>
+    </app1-root>
+    <app2-root>
+      <script><%= inlineCodeInvocation %></script>
+      <h2>App2 header</h2>
+      <span>content</span>
+    </app2-root>
+  </body>
+</html>
 ```
 
 #### Non-Angular Browser Configuration
 
-```
+```ts
 import { EventReplayer } from 'preboot';
 
 const replayer = new EventReplayer();
@@ -92,7 +113,7 @@ however where the page continues to change in significant ways. Basically if you
 the page after bootstrap then you will see some jank unless you set `replay` to `false` and then trigger replay
 yourself once you know that all async events are complete.
 
-To manually trigger replay, simply inject the EventReplayer like this:
+To manually trigger replay, inject the EventReplayer like this:
 
 ```
 import { Injectable } from '@angular/core';

--- a/src/lib/api/event.recorder.spec.ts
+++ b/src/lib/api/event.recorder.spec.ts
@@ -6,20 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {getMockElement} from '../common/preboot.mocks';
-import {createBuffer, createListenHandler, getSelection} from './event.recorder';
-import {
-  EventSelector,
-  PrebootAppData,
-  PrebootData,
-  PrebootSelection,
-  ServerClientRoot,
-} from '../common/preboot.interfaces';
+import {createBuffer, getSelection} from './event.recorder';
+import {PrebootSelection, ServerClientRoot} from '../common/preboot.interfaces';
 
 describe('UNIT TEST event.recorder', function() {
   describe('createBuffer()', function() {
     it('should do nothing if serverNode empty', function () {
       const root = <ServerClientRoot> {
-        serverSelector: 'body',
         serverNode: undefined
       };
 
@@ -29,7 +22,6 @@ describe('UNIT TEST event.recorder', function() {
 
     it('should clone the node and insert before', function () {
       const root = <ServerClientRoot> {
-        serverSelector: 'div',
         serverNode: getMockElement()
       };
       const clientNode = {
@@ -48,7 +40,6 @@ describe('UNIT TEST event.recorder', function() {
 
     it('should add the "ng-non-bindable" attribute to serverNode', function () {
       const root = <ServerClientRoot> {
-        serverSelector: 'div',
         serverNode: getMockElement()
       };
 
@@ -97,37 +88,6 @@ describe('UNIT TEST event.recorder', function() {
 
       const actual = getSelection(node as HTMLInputElement);
       expect(actual).toEqual(expected);
-    });
-  });
-
-
-  describe('createListenHandler()', function () {
-    it('should do nothing if not listening', function () {
-      const prebootData: PrebootData = <PrebootData> {
-        listening: false
-      };
-      const eventSelector: EventSelector = {
-        selector: '',
-        events: [''],
-        preventDefault: true
-      };
-      const appData: PrebootAppData = {
-        root: {
-          serverSelector: '',
-          serverNode: undefined
-        },
-        events: []
-      };
-      const event = {
-        preventDefault: function () {}
-      };
-      const node = <Element>{};
-
-      spyOn(event, 'preventDefault');
-
-      const handler = createListenHandler(prebootData, eventSelector, appData, node);
-      handler(event as Event);
-      expect(event.preventDefault).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/lib/api/event.replayer.ts
+++ b/src/lib/api/event.replayer.ts
@@ -18,7 +18,6 @@ import {getNodeKeyForPreboot} from '../common/get-node-key';
 export function _window(): PrebootWindow {
   return {
     prebootData: (window as any)['prebootData'],
-    prebootStarted: false,
     getComputedStyle: window.getComputedStyle,
     document: document
   };
@@ -77,16 +76,7 @@ export class EventReplayer {
 
     // try catch around events b/c even if error occurs, we still move forward
     try {
-      const root = <ServerClientRoot>(appData.root || {});
       const events = appData.events || [];
-
-      // some client side frameworks (like Angular 1 w UI Router) will replace
-      // elements, so we need to re-get client root just to be safe
-      const doc = this.getWindow().document;
-      const clientSelector = root.clientSelector;
-      if (clientSelector != null) {
-        root.clientNode = doc.querySelector(clientSelector) as HTMLElement;
-      }
 
       // replay all the events from the server view onto the client view
       events.forEach(event => this.replayEvent(appData, event));
@@ -190,7 +180,7 @@ export class EventReplayer {
 
     // remove the freeze overlay if it exists
     const doc = this.getWindow().document;
-    const prebootOverlay = doc.body.querySelector('#prebootOverlay') as HTMLElement;
+    const prebootOverlay = doc.getElementById('prebootOverlay');
     if (prebootOverlay) {
       prebootOverlay.remove ?
         prebootOverlay.remove() : prebootOverlay.parentNode !== null ?

--- a/src/lib/api/inline.preboot.code.spec.ts
+++ b/src/lib/api/inline.preboot.code.spec.ts
@@ -1,5 +1,9 @@
 import {
-  assign, getEventRecorderCode, getInlinePrebootCode, stringifyWithFunctions,
+  assign,
+  getEventRecorderCode,
+  getInlineDefinition,
+  getInlineInvocation,
+  stringifyWithFunctions,
   validateOptions
 } from './inline.preboot.code';
 import {PrebootOptions} from '../common/preboot.interfaces';
@@ -50,14 +54,16 @@ describe('UNIT TEST inline.preboot.code', function() {
     });
   });
 
-  describe('getInlinePrebootCode()', function () {
-    it('should generate valid JavaScript minified', function () {
-      const code = getInlinePrebootCode({ appRoot: 'foo' });
+  describe('getInlineDefinition()', function () {
+    it('should generate valid JavaScript', function () {
+      const code = getInlineDefinition({ appRoot: 'foo' });
       expect(code).toBeTruthy();
     });
+  });
 
-    it('should generate valid JavaScript not minified', function () {
-      const code = getInlinePrebootCode({ appRoot: 'foo', minify: false });
+  describe('getInlineInvocation()', function () {
+    it('should generate valid JavaScript', function () {
+      const code = getInlineInvocation();
       expect(code).toBeTruthy();
     });
   });

--- a/src/lib/common/get-node-key.spec.ts
+++ b/src/lib/common/get-node-key.spec.ts
@@ -6,14 +6,12 @@ describe('UNIT TEST get-node-key', function() {
     it('should generate a default name', function() {
       const nodeContext = <NodeContext>{
         root: {
-          serverSelector: '#myApp',
-          clientSelector: '#myApp',
           serverNode: {},
           clientNode: {},
         },
         node: {}
       };
-      const expected = 'unknown_#myApp';
+      const expected = 'unknown';
       const actual = getNodeKeyForPreboot(nodeContext);
       expect(actual).toEqual(expected);
     });
@@ -40,14 +38,13 @@ describe('UNIT TEST get-node-key', function() {
 
       const nodeContext = {
         root: {
-          serverSelector: '#myApp',
           serverNode,
           clientNode: emptyNode
         },
         node
       };
 
-      const expected = 'FOO_#myApp_s3_s2_s4';
+      const expected = 'FOO_s3_s2_s4';
       const actual = getNodeKeyForPreboot(nodeContext);
       expect(actual).toEqual(expected);
     });

--- a/src/lib/common/get-node-key.ts
+++ b/src/lib/common/get-node-key.ts
@@ -30,7 +30,7 @@ export function getNodeKeyForPreboot(nodeContext: NodeContext): string {
   // now go backwards starting from the root, appending the appName to unique
   // identify the node later..
   const name = node.nodeName || 'unknown';
-  let key = name + '_' + root.serverSelector;
+  let key = name;
   const len = ancestors.length;
 
   for (let i = len - 1; i >= 0; i--) {

--- a/src/lib/common/preboot.interfaces.ts
+++ b/src/lib/common/preboot.interfaces.ts
@@ -17,16 +17,14 @@ export interface EventSelector {
 }
 
 export interface ServerClientRoot {
-  serverSelector: string;
   serverNode?: HTMLElement;
-  clientSelector?: string;
   clientNode?: HTMLElement;
+  overlay?: HTMLElement;
 }
 
 // interface for the options that can be passed into preboot
 export interface PrebootOptions {
   /** @deprecated minification has been removed in v6 */
-  minify?: boolean;
   buffer?: boolean; // if true, attempt to buffer client rendering to hidden div
   eventSelectors?: EventSelector[]; // when any of these events occur, they are recorded
   appRoot: string | string[]; // define selectors for one or more server roots
@@ -58,7 +56,7 @@ export interface PrebootAppData {
 // object that is used to keep track of all the preboot
 // listeners (so we can remove the listeners later)
 export interface PrebootEventListener {
-  node: HTMLElement;
+  node: Node;
   eventName: string;
   handler: EventListener;
 }
@@ -82,7 +80,6 @@ export interface NodeContext {
 // interface for global object that contains all preboot data
 export interface PrebootData {
   opts?: PrebootOptions;
-  overlay?: Element;
   activeNode?: NodeContext;
   apps?: PrebootAppData[];
   listeners?: PrebootEventListener[];
@@ -90,7 +87,6 @@ export interface PrebootData {
 
 export interface PrebootWindow {
   prebootData: PrebootData;
-  prebootStarted: boolean;
   getComputedStyle: (elt: Element, pseudoElt?: string) => CSSStyleDeclaration;
   document: Document;
 }

--- a/src/lib/common/preboot.mocks.ts
+++ b/src/lib/common/preboot.mocks.ts
@@ -11,7 +11,6 @@ import {assign, defaultOptions} from '../api/inline.preboot.code';
 export function getMockWindow(): PrebootWindow {
   return {
     prebootData: {},
-    prebootStarted: false
   } as PrebootWindow;
 }
 

--- a/src/lib/provider.ts
+++ b/src/lib/provider.ts
@@ -18,11 +18,23 @@ import {filter, take} from 'rxjs/operators';
 
 import {EventReplayer} from './api/event.replayer';
 import {PREBOOT_NONCE} from './common/tokens';
-import {getInlinePrebootCode} from './api/inline.preboot.code';
+import {getInlineDefinition, getInlineInvocation} from './api/inline.preboot.code';
 import {PrebootOptions} from './common/preboot.interfaces';
+import {validateOptions} from './api';
 
-const PREBOOT_SCRIPT_ID = 'preboot-inline-script';
+const PREBOOT_SCRIPT_CLASS = 'preboot-inline-script';
 export const PREBOOT_OPTIONS = new InjectionToken<PrebootOptions>('PrebootOptions');
+
+function createScriptFromCode(doc: Document, nonce: string|null, inlineCode: string) {
+  const script = doc.createElement('script');
+  if (nonce) {
+    (script as any).nonce = nonce;
+  }
+  script.className = PREBOOT_SCRIPT_CLASS;
+  script.textContent = inlineCode;
+
+  return script;
+}
 
 export function PREBOOT_FACTORY(doc: Document,
                                 prebootOpts: PrebootOptions,
@@ -31,22 +43,36 @@ export function PREBOOT_FACTORY(doc: Document,
                                 appRef: ApplicationRef,
                                 eventReplayer: EventReplayer) {
   return () => {
-    if (isPlatformServer(platformId)) {
-      const inlineCode = getInlinePrebootCode(prebootOpts);
-      const script = doc.createElement('script');
-      if (nonce) {
-        (<any>script)['nonce'] = nonce;
-      }
-      script.id = PREBOOT_SCRIPT_ID;
-      script.textContent = inlineCode;
-      const existingScripts = doc.querySelectorAll(`#${PREBOOT_SCRIPT_ID}`);
+    validateOptions(prebootOpts);
 
-      // Check to see if a preboot script is already inlined before adding
-      // it to the DOM. If it is, update the nonce to be current
+    if (isPlatformServer(platformId)) {
+      const inlineCodeDefinition = getInlineDefinition(prebootOpts);
+      const scriptWithDefinition = createScriptFromCode(doc, nonce, inlineCodeDefinition);
+      const inlineCodeInvocation = getInlineInvocation();
+
+      const existingScripts = doc.getElementsByClassName(PREBOOT_SCRIPT_CLASS);
+
+      // Check to see if preboot scripts are already inlined before adding them
+      // to the DOM. If they are, update the nonce to be current.
       if (existingScripts.length === 0) {
-        doc.head.appendChild(script);
+        const baseList: string[] = [];
+        const appRootSelectors = baseList.concat(prebootOpts.appRoot);
+        doc.head.appendChild(scriptWithDefinition);
+        appRootSelectors
+          .map(selector => ({
+            selector,
+            appRootElem: doc.querySelector(selector)
+          }))
+          .forEach(({selector, appRootElem}) => {
+            if (!appRootElem) {
+              console.log(`No server node found for selector: ${selector}`);
+              return;
+            }
+            const scriptWithInvocation = createScriptFromCode(doc, nonce, inlineCodeInvocation);
+            appRootElem.insertBefore(scriptWithInvocation, appRootElem.firstChild);
+          });
       } else if (existingScripts.length > 0 && nonce) {
-        (<any>existingScripts[0])['nonce'] = nonce;
+        (existingScripts[0] as any).nonce = nonce;
       }
     }
     if (isPlatformBrowser(platformId)) {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/preboot/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [x] server side
- [x] client side
- [x] inline
- [ ] build process
- [ ] docs
- [ ] tests

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
remove unused proxy imports from some test files

A bug fix via a refactor.

* **What is the current behavior?** (You can also link to an open issue here)

See #82.

* **What is the new behavior (if this is a feature change)?**

There should be no race conditions.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Yes, at least in the inline code handling as it no longer waits for the app root to be available so it cannot be fully put in `<head>`.

* **Other information**:

Currently Preboot suffers from various race conditions:

1. It waits for the `document.body` to be available and then applies its logic.
However, the application root may not be available at this point - see the issue
#72.

2. Even if the application root exists when Preboot starts listening for events
the server node may not be available in full yet. Since Preboot searches for
nodes matching desired selectors inside of the existing `serverNode`, it may
skip some of them if the server node hasn't loaded fully. This is especially
common if the internet connection is slow.

3. Preboot waits for `body` in a tight loop, checking every 10 milliseconds.
This starves the browser but may also be clamped by it to a larger delay
(around 1 second); that's what happens in modern browsers if the tab where the
page loads is inactive which is what happens if you open a link in a new tab in
Chrome or Firefox. This means Preboot may start listening for events after
Angular reports the app is stable and the `PrebootComplete` event fires. This
then leaves the server node active, never transferring to the client one which
makes for a broken site.

To solve it, we're doing the following:

1. Since we want to attach event listeners as soon as possible when the server
node starts being available (so that it can be shallow-cloned) we cannot wait
for it to be available in full. Therefore, we switched to delegated event
handlers on each of the app roots instead of directly on specific nodes.

2. As we support multiple app roots, to not duplicate large inline preboot code,
we've split `getInlinePrebootCode` into two parts: function definitions to be
put in `<head>` and the invocation separate for each app root put just after
the app root opening tag.

3. To maintain children offset numbers (otherwise selectors won't match between
the client & the server) we've removed the in-app-root script immediately when
it starts executing; this won't stop the execution. `document.currentScript` is
a good way to find the currently running script but it doesn't work in IE. A
fallback behavior is applied to IE that leverages the fact that start scripts
are invoked synchronously so the current script is the last one currently in
the DOM.

4. We've removed `waitUntilReady` as there's no reliable way to wait; we'll
invoke the init code immediately instead.

5. We've switched the overlay used for freeing the UI to attach to
`document.documentElement` instead of `document.body` so that we don't have to
wait for `body`.

6. The mentioned overlay is now created for each app root separately to avoid
race conditions.

Fixes #82
Fixes #72

BREAKING CHANGES:

1. When used in a non-Angular app, the code needs to be updated to use
`getInlineDefinition` and `getInlineInvocation`; the previously defined
`getInlinePrebootCode` has been removed. The `getInlineDefinition` output
needs to be placed before any content user might interactive with, preferably
in <head>. The `getInlineInvocation` output needs to be put just after the
opening tag of each app root. Only `getInlineDefinition` needs to have options
passed. An example expected (simplified) layout in EJS format:

```html
<html>
  <head>
    <script><%= getInlineDefinition(options) %></script>
  </head>
  <body>
    <app1-root>
      <script><%= getInlineInvocation() %></script>
      <h2>App1 header</h2>
      <div>content</div>
    </app1-root>
    <app2-root>
      <script><%= getInlineInvocation() %></script>
      <h2>App2 header</h2>
      <span>content</span>
    </app2-root>
  </body>
</html>
```

2. The refactor breaks working with frameworks that replace elements
like AngularJS with UI Router as it no longer uses serverSelector and
clientSelector but expects its clientNode to remain in the DOM.

TODO:
- [x] Make it work in IE: add a fallback for missing `document.currentScript`.
- [x] Make sure it works correctly for multiple app roots. ~~Maybe switch the selectors to be scoped to the concrete app root so that they don't interfere with each other?~~ (we're now attaching delegated handlers to the server node, not to document). This may be an issue as we now have separate code for each app root. We need to switch the logic to not use the `appRoots` array as each of the app roots is now handled separately.
- [ ] Write some tests? (although the current code is not well tested either so that may require significant time investment)
- [x] Decide whether to remove `getInlinePrebootCode`.