### PR TITLE
Fix: Currentscript is now used within start function.

### DIFF
--- a/src/lib/api/event.recorder.ts
+++ b/src/lib/api/event.recorder.ts
@@ -73,7 +73,7 @@ export function start(prebootData: PrebootData, win?: PrebootWindow) {
     return;
   }
 
-  serverNode.removeChild(_document.currentScript);
+  serverNode.removeChild(currentScript);
 
   const opts = prebootData.opts || ({} as PrebootOptions);
   let eventSelectors = opts.eventSelectors || [];


### PR DESCRIPTION
A fallback was made for _document.currentScript. Except when trying to remove the child from the serverNode, it did not use the fallback.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/preboot/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [ ] server side
- [ ] client side
- [x] inline
- [ ] build process
- [ ] docs
- [ ] tests

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
remove unused proxy imports from some test files
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/angular/preboot/issues/93


* **What is the new behavior (if this is a feature change)?**
It fixes the use of currentScript.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
