### PR TITLE
fix(EventRecorder): Maintain focus for nodes besides input and textarea

### DIFF
--- a/src/lib/api/event.recorder.ts
+++ b/src/lib/api/event.recorder.ts
@@ -253,14 +253,16 @@ export function createListenHandler(
     // get the node key for a given node
     const nodeKey = getNodeKeyForPreboot({ root: root, node: node });
 
-    // if event on input or text area, record active node
-    if (CARET_EVENTS.indexOf(eventName) >= 0 &&
-      CARET_NODES.indexOf(node.tagName ? node.tagName : '') >= 0) {
+    // record active node
+    if (CARET_EVENTS.indexOf(eventName) >= 0) {
+      // if it's an caret node, get the selection for the active node
+      const isCaretNode = CARET_NODES.indexOf(node.tagName ? node.tagName : '') >= 0;
+
       prebootData.activeNode = {
         root: root,
         node: node,
         nodeKey: nodeKey,
-        selection: getSelection(node as HTMLInputElement)
+        selection: isCaretNode ? getSelection(node as HTMLInputElement) : undefined
       };
     } else if (eventName !== 'change' && eventName !== 'focusout') {
       prebootData.activeNode = undefined;


### PR DESCRIPTION
In this change, the activeNode in Preboot is set for any focus event, not
just those in `<input>` or `<textarea>`.
This helps those who use screenreaders maintain focus during
the swap between server and client views.

Closes https://github.com/angular/preboot/issues/105

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/preboot/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [ ] server side
- [x] client side
- [x] inline
- [ ] build process
- [ ] docs
- [ ] tests

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
remove unused proxy imports from some test files
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/angular/preboot/issues/105


* **What is the new behavior (if this is a feature change)?**
`activeNode` is set for `focus` on any element, not just `input` and `textarea`


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
