### PR TITLE
fix(typings): Fix Preboot Typings to accept multiple events.

### DIFF
--- a/src/lib/common/preboot.interfaces.ts
+++ b/src/lib/common/preboot.interfaces.ts
@@ -8,8 +8,8 @@
 // This is used to identify which events to listen for and what we do with them
 export interface EventSelector {
   selector: string; // same as jQuery; selector for nodes
-  events: [string]; // array of event names to listen for
-  keyCodes?: [number]; // key codes to watch out for
+  events: string[]; // array of event names to listen for
+  keyCodes?: number[]; // key codes to watch out for
   preventDefault?: boolean; // will prevent default handlers if true
   freeze?: boolean; // if  true, the UI will freeze when this event occurs
   action?: Function; // custom action to take with this event


### PR DESCRIPTION
- The current behavior is that the "events" and "keycodes" property are allowed an array of one item.
- The new behavior is that these properties now may have an array of any length.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/preboot/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What modules are related to this pull-request**
- [ ] server side
- [ ] client side
- [ ] inline
- [x] build process
- [ ] docs
- [ ] tests

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
remove unused proxy imports from some test files
A TypeScript typings fix.

* **What is the current behavior?** (You can also link to an open issue here)
In the `EventSelector` interface, only arrays of one item are allowed for `keyCodes` and `events`.


* **What is the new behavior (if this is a feature change)?**
In the `EventSelector` interface, arrays of varying length are allowed for `keyCodes` and `events`.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
